### PR TITLE
[OrderLink-frontend] キッチン画面の表記をわかりやすい形に変更

### DIFF
--- a/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/FilterModal.tsx
+++ b/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/FilterModal.tsx
@@ -57,7 +57,7 @@ export function FilterModal(props: Props) {
             onChange={() => allCheckChange(!isAllFilterChecked)}
             isChecked={isAllFilterChecked}
           >
-            全件表示
+            商品すべて
           </Checkbox>
           <FilterAccordion
             tempFilter={tempFilter}
@@ -68,14 +68,13 @@ export function FilterModal(props: Props) {
         </ModalBody>
         <ModalFooter>
           <Button
-            leftIcon={<FaReact />}
             size="md"
             w="full"
             colorScheme="red"
             mr="3"
             onClick={() => allCheckChange(false)}
           >
-            絞り込みクリア
+            絞り込み解除
           </Button>
           <Button leftIcon={<MdOutlineDone />} size="md" w="full" colorScheme="green" onClick={onConfirm}>
             確定

--- a/orderlink-frontend/app/(base)/(coreapp)/kitchen/page.tsx
+++ b/orderlink-frontend/app/(base)/(coreapp)/kitchen/page.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { Button, Flex, HStack, Text, VStack } from '@chakra-ui/react';
-import { FiCheckSquare, FiRepeat } from 'react-icons/fi';
+import { Button, Flex, HStack, Spacer, Text, VStack } from '@chakra-ui/react';
+import { FiRepeat } from 'react-icons/fi';
+import { MdFilterListAlt } from 'react-icons/md';
 import { IoReloadOutline } from 'react-icons/io5';
 
 import { FilterModal } from '@/app/(base)/(coreapp)/kitchen/_components/FilterModal';
@@ -136,10 +137,18 @@ export default function KitchenPage() {
           >
             再読込
           </Button>
-          <Button leftIcon={<FiCheckSquare />} color="white" size="lg" bg="blue.500" onClick={onOpenFilterModal}>
+          <Spacer />
+          <Button leftIcon={<MdFilterListAlt />} color="white" size="lg" bg="blue.500" onClick={onOpenFilterModal}>
             絞り込み
           </Button>
-          <Button leftIcon={<FiRepeat />} color="white" size="lg" bg="orange.500" onClick={onToggleShowOnlyMyTasks}>
+          <Button
+            leftIcon={<FiRepeat />}
+            colorScheme="orange"
+            variant={isOnlyMyTasks ? 'solid' : 'outline'}
+            size="lg"
+            borderRadius={80}
+            onClick={onToggleShowOnlyMyTasks}
+          >
             担当分表示{isOnlyMyTasks ? '中' : ''}
           </Button>
         </HStack>

--- a/orderlink-frontend/ui/CancelButton.tsx
+++ b/orderlink-frontend/ui/CancelButton.tsx
@@ -6,10 +6,11 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalBody,
 } from '@chakra-ui/react';
 import React from 'react';
 import { IconContext } from 'react-icons';
-import { MdOutlineClear } from 'react-icons/md';
+import { BiUndo } from 'react-icons/bi';
 
 type Props = React.ComponentProps<typeof Button> & {
   onCancel?: () => void;
@@ -44,21 +45,24 @@ export function CancelButton(props: Props) {
         onClick={onClick}
       >
         <IconContext.Provider value={{ size: '2rem' }}>
-          <MdOutlineClear />
+          <BiUndo />
         </IconContext.Provider>
         取消
       </Button>
       <Modal isOpen={isModalOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>本当に操作を取り消しますか？</ModalHeader>
+          <ModalHeader>1つ前の調理ステータスに戻しますか？</ModalHeader>
           <ModalCloseButton />
+          <ModalBody>
+            この操作を行なっても、注文はキャンセルされません。
+          </ModalBody>
           <ModalFooter>
             <Button size="md" w="full" onClick={onClose} mr="3">
               キャンセル
             </Button>
             <Button size="md" w="full" colorScheme="red" onClick={onCancel}>
-              取り消し
+              ステータスを戻す
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/orderlink-frontend/ui/FilterAccordion.tsx
+++ b/orderlink-frontend/ui/FilterAccordion.tsx
@@ -21,38 +21,60 @@ type Props = {
 
 export function FilterAccordion({tempFilter, onChildCheckChange, onGrandChildCheckChange, onParentCheckChange}: Props) {
   return (
-    <Accordion allowMultiple defaultIndex={[0]}>
+    <Box>
       {tempFilter.map((item) => (
-        <AccordionItem key={item.name}>
-          <AccordionButton>
-            <Text fontSize="2xl" fontWeight="semibold">
-              {item.name}
-            </Text>
-            <AccordionIcon />
-          </AccordionButton>
-          <AccordionPanel>
+        <Box key={item.name} mb={4}>
+          <Box mb={2}>
+            {/* ヘッダー */}
+            <Box bg="gray.100" p={2} borderY="1px" borderColor="gray.300">
+              <Text fontSize="xl" fontWeight="semibold">
+                {item.name}
+              </Text>
+            </Box>
+
             <Checkbox
               size="lg"
               fontSize="2xl"
               fontWeight="semibold"
               isChecked={item.checked}
               onChange={() => onParentCheckChange(item, !item.checked)}
+              margin={3}
             >
-              {item.name}
+              {item.name}すべて（{(item.children?.length || 0) + (item.children?.flatMap(child => child.children)?.length || 0)}）
             </Checkbox>
-            <Box mt="2" px="4">
+          </Box>
+          <Box mt="2" px="4">
               {item.children?.map((child) => (
-                <Box key={child.name}>
+                <Box key={child.name} mb={2}>
+                  {child.children && child.children.length > 0 ? (
+                    <Text fontSize="xl" fontWeight="semibold">
+                      {child.name}
+                    </Text>
+                  ) : (
+                    <Checkbox
+                      size="lg"
+                      fontSize="xl"
+                      fontWeight="semibold"
+                      isChecked={child.checked}
+                      onChange={() => onChildCheckChange(item, child, !child.checked)}
+                      mr="4"
+                    >
+                      {child.name}
+                    </Checkbox>
+                  )}
+                  <Flex justifyContent="flex-end">
+                  {Array.isArray(child.children) && child.children.length > 0 && (
                   <Checkbox
                     size="lg"
                     fontSize="xl"
                     fontWeight="semibold"
                     isChecked={child.checked}
                     onChange={() => onChildCheckChange(item, child, !child.checked)}
+                    mr="4"
                   >
-                    {child.name}
-                  </Checkbox>
-                  <Flex justifyContent="flex-end">
+                      すべて
+                    </Checkbox>
+                  )}
                     {child.children?.map((grandChild) => (
                       <Checkbox
                         key={grandChild.name}
@@ -64,15 +86,15 @@ export function FilterAccordion({tempFilter, onChildCheckChange, onGrandChildChe
                         onChange={() => onGrandChildCheckChange(item, child, grandChild, !grandChild.checked)}
                       >
                         {grandChild.name}
-                      </Checkbox>
-                    ))}
-                  </Flex>
+                        </Checkbox>
+                      ))}
+                    </Flex>
+                  
                 </Box>
-              ))}
-            </Box>
-          </AccordionPanel>
-        </AccordionItem>
+            ))}
+          </Box>
+        </Box>
       ))}
-    </Accordion>
+    </Box>
   );
 }


### PR DESCRIPTION
# 概要
- 「取り消し」が「undo」だとわかりづらい問題をアイコンとModalで解消
- 絞り込み機能のチェックボックスが何を表示させるのかわかりにくい問題を「すべて」チェックボックスを設置することで解消
- 「担当分表示」を表示中・未表示時で色を変えることで、どちらを表示しているか視覚的にわかりやすくした
  - 角を丸くしてToggleっぽくした

# 検証方法
- 単体ではデバッグ済み
- とりあえず動かしてみる