### PR TITLE
[OLF] スタッフ画面のチェックボックスサイズを大きくする

### DIFF
--- a/orderlink-frontend/app/(base)/(coreapp)/staff/_components/ItemCard.tsx
+++ b/orderlink-frontend/app/(base)/(coreapp)/staff/_components/ItemCard.tsx
@@ -41,6 +41,11 @@ function ProductItem(props: ProductItemProps) {
                   return rebuildMap(newMap);
                 });
               }}
+              sx={{
+                '& .chakra-checkbox__control': {
+                  transform: 'scale(1.25)',
+                },
+              }}
             >
               <Flex alignItems="center">
                 {item.status === 'done' ? (


### PR DESCRIPTION
# タスクのURL
https://www.notion.so/cirkit/OLF-b819bde51f514cb48d68feea815943df?pvs=4

# 概要
- スタッフ画面のチェックボックスを1.25倍している

| before | after |
| -- | -- |
|![image](https://github.com/user-attachments/assets/df29a8a3-9e23-43aa-9162-2406733444e2)|![image](https://github.com/user-attachments/assets/3c10d2cd-9e49-4bdd-9c3d-04932f495fef)|


# 検証手法
- スタッフ画面を開く

# 未解決事項
- なし