### PR TITLE
aquaとairで開発環境を整え直す

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export PATH="$(aqua root-dir)/bin:$PATH"
+aqua install -l

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 .idea
 .next
+
+**/tmp

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,104 @@
+version: '3'
+
+env:
+  SENTRY_DSN: example
+  DEV_MODE: 1
+
+tasks:
+  dev:
+    deps:
+      - task: dev:docker
+      - task: dev:logoregi-backend
+      - task: dev:orderlink-backend
+      - task: dev:orderlink-frontend
+      - task: dev:logoregi-handy
+      - task: dev:logoregi-admin
+
+  dev:docker:
+    cmd: docker compose up db redis ticket-backend
+
+  dev:logoregi-backend:
+    dir: ./logoregi-backend
+    cmd: aqua exec air
+
+  dev:orderlink-backend:
+    dir: ./orderlink-backend
+    cmd: aqua exec air
+
+  dev:orderlink-frontend:
+    dir: ./orderlink-frontend
+    deps:
+      - task: dev:orderlink-frontend:install
+    cmd: bun dev
+    env:
+      PORT: 3001
+      NEXT_PUBLIC_WEBSOCKET_API: ws://localhost:8082/
+      NEXT_PUBLIC_GRPC_HOST: http://localhost:8080
+
+  dev:orderlink-frontend:install:
+    dir: ./orderlink-frontend
+    cmd: bun install --frozen-lockfile
+
+  dev:logoregi-handy:
+    dir: ./logoregi-handy
+    deps:
+      - task: dev:logoregi-handy:install
+    cmd: bun dev
+    env:
+      PORT: 3002
+      NEXT_PUBLIC_POS_GRPC: http://localhost:8080
+
+  dev:logoregi-handy:install:
+    dir: ./logoregi-handy
+    cmd: bun install --frozen-lockfile
+
+  dev:logoregi-admin:
+    dir: ./logoregi-admin
+    deps:
+      - task: dev:logoregi-admin:install
+    cmd: bun dev
+    env:
+      PORT: 3000
+      NEXT_PUBLIC_GRPC_HOST: http://localhost:8080
+
+  dev:logoregi-admin:install:
+    dir: ./logoregi-admin
+    cmd: bun install --frozen-lockfile
+
+  init:
+    deps:
+      - task: init:logoregi
+      - task: init:orderlink
+
+  init:logoregi:
+    dir: ./logoregi-backend
+    cmd: aqua exec go run ./cmd/bin/main.go db init
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost/pos?sslmode=disable
+
+  init:orderlink:
+    dir: ./orderlink-backend
+    cmd: aqua exec go run ./cmd/bin/main.go db init
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost/orderlink?sslmode=disable
+
+  migrate:
+    deps:
+      - task: migrate:logoregi
+      - task: migrate:orderlink
+
+  migrate:logoregi:
+    dir: ./logoregi-backend
+    cmd: aqua exec go run ./cmd/bin/main.go db migrate
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost/pos?sslmode=disable
+
+  migrate:orderlink:
+    dir: ./orderlink-backend
+    cmd: aqua exec go run ./cmd/bin/main.go db migrate
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost/orderlink?sslmode=disable
+
+  psql:
+    cmd: docker compose run --rm db psql -U postgres -h db
+

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.319.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: golang/go@go1.24.0
+- name: oven-sh/bun@bun-v1.2.2
+- name: direnv/direnv@v2.35.0
+- name: air-verse/air@v1.61.7
+- name: go-task/task@v3.41.0

--- a/compose.yml
+++ b/compose.yml
@@ -14,55 +14,6 @@ services:
       - '6379:6379'
     volumes:
       - redis-data:/data
-  logoregi-backend:
-    build:
-      context: ./logoregi-backend
-    ports:
-      - '8080:8080'
-    command: go run .
-    environment:
-      - DATABASE_URL=postgres://postgres:password@db/pos?sslmode=disable
-      - PORT=8080
-      - TICKET_GRPC=http://ticket-backend:8081
-      - ORDERLINK_GRPC=http://orderlink-backend:8082
-      - DEV_MODE=1
-    volumes:
-      - ./logoregi-backend:/app
-    depends_on:
-      - db
-      - ticket-backend
-  logoregi-admin:
-    build:
-      context: ./logoregi-admin
-      args:
-        - NEXT_PUBLIC_GRPC_HOST=http://localhost:8080
-    stdin_open: true
-    tty: true
-    command: /bin/sh -c 'bun install --frozen-lockfile && bun run dev'
-    ports:
-      - '3000:3000'
-    environment:
-      - PORT=3000
-    volumes:
-      - ./logoregi-admin:/usr/src/app/logos
-    depends_on:
-      - logoregi-backend
-  logoregi-handy:
-    build:
-      context: ./logoregi-handy
-      args:
-        - NEXT_PUBLIC_POS_GRPC=http://localhost:8080
-    stdin_open: true
-    tty: true
-    command: /bin/sh -c 'bun install --frozen-lockfile && bun run dev'
-    ports:
-      - '3002:3002'
-    environment:
-      - PORT=3002
-    volumes:
-      - ./logoregi-handy:/usr/src/app/logos
-    depends_on:
-      - logoregi-backend
   ticket-backend:
     build:
       context: ./ticket-backend
@@ -71,40 +22,6 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:password@db/ticket?sslmode=disable
       - PORT=8081
-  orderlink-backend:
-    build:
-      context: ./orderlink-backend
-    ports:
-      - '8082:8082'
-    command: go run .
-    environment:
-      - DATABASE_URL=postgres://postgres:password@db/orderlink?sslmode=disable
-      - SENTRY_DSN=example
-      - PORT=8082
-      - REDIS_URL=redis:6379
-      - DEV_MODE=1
-    volumes:
-      - ./orderlink-backend:/app
-    depends_on:
-      - db
-      - redis
-  orderlink-frontend:
-    build:
-      context: ./orderlink-frontend
-      args:
-        - NEXT_PUBLIC_WEBSOCKET_API=ws://localhost:8082/
-        - NEXT_PUBLIC_GRPC_HOST=http://localhost:8080
-    stdin_open: true
-    tty: true
-    command: /bin/sh -c 'bun install --frozen-lockfile && bun run dev'
-    ports:
-      - '3001:3001'
-    environment:
-      - PORT=3001
-    volumes:
-      - ./orderlink-frontend:/usr/src/app/logos
-    depends_on:
-      - orderlink-backend
 
 volumes:
   db-data:

--- a/logoregi-backend/.air.toml
+++ b/logoregi-backend/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "DATABASE_URL=postgres://postgres:password@localhost/pos?sslmode=disable PORT=8080 TICKET_GRPC=http://localhost:8081 ORDERLINK_GRPC=http://localhost:8082 DEV_MODE=1 ./tmp/main"
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/logoregi-backend/Dockerfile
+++ b/logoregi-backend/Dockerfile
@@ -1,6 +1,6 @@
 
 # FROM: https://github.com/docker/docker-gs-ping/blob/main/Dockerfile
-FROM golang:1.23
+FROM golang:1.24
 
 # Set destination for COPY
 WORKDIR /app

--- a/logoregi-backend/cmd/bin/migrations/20241018222113_add_ol_flag_to_products.go
+++ b/logoregi-backend/cmd/bin/migrations/20241018222113_add_ol_flag_to_products.go
@@ -15,7 +15,7 @@ func init() {
 			if _, err := tx.NewRaw("UPDATE products SET is_managing_order = TRUE").Exec(ctx); err != nil {
 				return err
 			}
-			if _, err := tx.NewRaw("ALTER TABLE products ALTER COLUMN IF NOT EXISTS is_managing_order SET NOT NULL").Exec(ctx); err != nil {
+			if _, err := tx.NewRaw("ALTER TABLE products ALTER COLUMN IF NOT EXISTS is_managing_order ADD NOT NULL").Exec(ctx); err != nil {
 				return err
 			}
 
@@ -25,7 +25,7 @@ func init() {
 			if _, err := tx.NewRaw("UPDATE products SET is_ol_use_kitchen = TRUE").Exec(ctx); err != nil {
 				return err
 			}
-			if _, err := tx.NewRaw("ALTER TABLE products ALTER COLUMN IF NOT EXISTS is_ol_use_kitchen SET NOT NULL").Exec(ctx); err != nil {
+			if _, err := tx.NewRaw("ALTER TABLE products ALTER COLUMN IF NOT EXISTS is_ol_use_kitchen ADD NOT NULL").Exec(ctx); err != nil {
 				return err
 			}
 			return nil

--- a/logoregi-backend/go.mod
+++ b/logoregi-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/KaguraGateway/logosone/logoregi-backend
 
-go 1.23
+go 1.24.0
 
 require (
 	connectrpc.com/connect v1.17.0
@@ -8,6 +8,7 @@ require (
 	github.com/cockroachdb/errors v1.11.3
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/rs/cors v1.11.1
+	github.com/stretchr/testify v1.8.4
 	github.com/uptrace/bun/extra/bundebug v1.2.3
 	golang.org/x/net v0.30.0
 )

--- a/logoregi-backend/go.sum
+++ b/logoregi-backend/go.sum
@@ -83,6 +83,7 @@ github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
 github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/uptrace/bun v1.2.3 h1:6KDc6YiNlXde38j9ATKufb8o7MS8zllhAOeIyELKrk0=

--- a/orderlink-backend/.air.toml
+++ b/orderlink-backend/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "DATABASE_URL=postgres://postgres:password@localhost/orderlink?sslmode=disable SENTRY_DSN=example PORT=8082 REDIS_URL=localhost:6379 DEV_MODE=1 ./tmp/main"
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/orderlink-backend/Dockerfile
+++ b/orderlink-backend/Dockerfile
@@ -1,6 +1,6 @@
 
 # FROM: https://github.com/docker/docker-gs-ping/blob/main/Dockerfile
-FROM golang:1.23
+FROM golang:1.24
 
 # Set destination for COPY
 WORKDIR /app

--- a/orderlink-backend/go.mod
+++ b/orderlink-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/KaguraGateway/logosone/orderlink-backend
 
-go 1.23
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.44.0


### PR DESCRIPTION
# Why
開発環境を立てるとDocker Imageだけで20GBくらい必要で、またIOもネックで問題が多かったため。
aquaでローカル環境で環境を整えやすくすることでDockerに載せなくてもいいように解決する。

# 試し方
```
brew install aquaproj/aqua/aqua
brew install direnv
cd logosone
direnv allow
aqua exec task dev
```