### PR TITLE
fix(OLF): 調理完了済のオーダーをタップした時に要素がdisableのままになる問題を修正

### DIFF
--- a/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/ItemInfoCard.tsx
+++ b/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/ItemInfoCard.tsx
@@ -40,7 +40,7 @@ export function ItemInfoCard({
     setIsSubmittable(true);
   }, [cookingStatus, setIsSubmittable]);
 
-  const isNextStateButtonDisabled = cookingStatus === 'done' || !isSubmittable;
+  const isTransitionToNextStateDisabled = cookingStatus === 'done' || !isSubmittable;
 
   return (
     <Flex
@@ -73,7 +73,7 @@ export function ItemInfoCard({
         flex="1"
         border="none"
         outline="0"
-        disabled={isNextStateButtonDisabled}
+        disabled={isTransitionToNextStateDisabled}
         onClick={() => {
           setIsSubmittable(false);
           onNextState?.(itemId);

--- a/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/ItemInfoCard.tsx
+++ b/orderlink-frontend/app/(base)/(coreapp)/kitchen/_components/ItemInfoCard.tsx
@@ -5,7 +5,7 @@ import { Badge, Button, Flex, Text, VStack } from '@chakra-ui/react';
 import { CancelButton } from '@/ui/CancelButton';
 
 import { CookingDoneBox, CookingStartBox, CookingTakingBox } from './CookingStatusButton';
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 
 export type ItemInfoCardProps = {
   itemId: string;
@@ -40,6 +40,8 @@ export function ItemInfoCard({
     setIsSubmittable(true);
   }, [cookingStatus, setIsSubmittable]);
 
+  const isNextStateButtonDisabled = cookingStatus === 'done' || !isSubmittable;
+
   return (
     <Flex
       alignItems="center"
@@ -71,7 +73,7 @@ export function ItemInfoCard({
         flex="1"
         border="none"
         outline="0"
-        disabled={!isSubmittable}
+        disabled={isNextStateButtonDisabled}
         onClick={() => {
           setIsSubmittable(false);
           onNextState?.(itemId);


### PR DESCRIPTION
# タスクチケット
https://www.notion.so/cirkit/OLF-disable-ecddf94f80aa4d52a18daea34f33af35

# 概要

<!-- DO NOT EDIT -->
### 🤖 Generated by PR Agent at 39d74bf2120b9260b36eb97ed5494d43a7fa28d2

- ボタン無効化条件の改善
- コードのフォーマット調整


# Walkthrough
<!-- DO NOT EDIT -->
pr_agent:walkthrough

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>